### PR TITLE
ci: fixed release note generation using wrong commits

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,7 +41,7 @@ jobs:
         id: changelog
         with:
           config: cliff.toml
-          args: --verbose -t ${{ github.event.inputs.version }} --latest
+          args: --verbose -t ${{ github.event.inputs.version }} --unreleased --sort newest
         env:
           OUTPUT: CHANGELOG.md
           GITHUB_REPO: ${{ github.repository }}


### PR DESCRIPTION
Closes #19 